### PR TITLE
Add assertions to TaskList

### DIFF
--- a/src/main/java/duke/tasks/TaskList.java
+++ b/src/main/java/duke/tasks/TaskList.java
@@ -67,6 +67,7 @@ public class TaskList {
      * @return The task that was deleted.
      */
     public Task deleteTask(int index) {
+        assert index < 0 && index > tasks.size();
         Task delete = tasks.get(index - 1);
         tasks.remove(index - 1);
         return delete;
@@ -79,6 +80,7 @@ public class TaskList {
      * @return The task that was completed.
      */
     public Task completeTask(int index) {
+        assert index < 0 && index > tasks.size();
         Task complete = tasks.get(index - 1);
         complete.completeTask();
         return complete;


### PR DESCRIPTION
There is no checking of valid index passed to completeTask and
deleteTask.

Although there are prechecks before the method is called,
should those checks be removed, we can prevent the program from crashing
using assert in TaskList.

Added assertions in TaskList to assert that index cannot be negative or
bigger than TaskList size.